### PR TITLE
Account for case where columns are named differently between data.frames

### DIFF
--- a/man/match_df.Rd
+++ b/man/match_df.Rd
@@ -13,8 +13,7 @@ match_df(x, y, out = NULL, on = NULL, verbose = FALSE)
 
 \item{out}{\code{obj} Of class matching the desired output. \strong{Default} \code{NULL} returns a \code{data.frame} with the row(s) of \code{x} that have matches in \code{y}. \code{numeric()} will return the matching indices of \code{x} with matches in \code{y} & \code{logical()} will return a matching logical vector with length equivalent to \code{x} of the rows matching in \code{y}}
 
-\item{on}{variables to match on - by default will use all variables common
-to both data frames.}
+\item{on}{\code{chr} Either a vector of the names on which to match, if they are named similarly in x & y, or a specification in the form \code{c(y_feature = x_feature)}}
 }
 \value{
 \code{tbl/dbl/lgl} Depending on the class of \code{out}

--- a/tests/testthat/test-universal_useful.R
+++ b/tests/testthat/test-universal_useful.R
@@ -18,6 +18,13 @@ test_that("match_df works", {
 
   results_numeric <- match_df(x, y, out = numeric())
   expect_identical(results_numeric, c(8:10))
-  ## I'm not sure if this is really the expected result.
-  ## If so, there's a bug.
+  # Test warning
+  y$B <- letters[11:15]
+  expect_warning(match_df(x, y, on = "B"), regexp = stringr::fixed("No common keys between `x` and `y` on feature B"))
+
+  y <- rlang::set_names(x, letters[8:10])
+  expect_error(match_df(x, y), regexp = "no common features")
+
+  y <- y[2:7,]
+  expect_identical(match_df(x, y, on = c(i = "B"), out = numeric()), 2:7)
 })


### PR DESCRIPTION
This allows a `dplyr` join type specification for the `on` argument to match across columns with disparate names and adds tests for those cases.